### PR TITLE
Use structlog for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ create `.env` file with variable `SD_DEBUG=1` and load it to your environment.
 $ echo "SD_DEBUG=1" > .env
 $ source .env
 ```
+Since [structlog](http://www.structlog.org/en/stable/) is used for logging,
+you can have nice **colorized output** in the CLI. You just need to install [colorama](https://github.com/tartley/colorama).
+```bash
+$ pip3 install colorama
+```
+You can also switch between JSON logs renderer good for logs management services (enabled by `JSON_LOGS=1`) or console render.
+```bash
+$ echo "JSON_LOGS=1" >> .env
+```
 
 # References
 

--- a/sentinel_downloader/settings.py
+++ b/sentinel_downloader/settings.py
@@ -25,3 +25,4 @@ import os
 
 
 debug = os.getenv("SD_DEBUG", False)
+json_logs = os.getenv("JSON_LOGS", False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     opencv-python
     jsonschema
     pyyaml
+    structlog
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Use [structlog](http://www.structlog.org/en/stable/) instead off logging. The best advantage is that it supports kwargs, json logs and colored logs